### PR TITLE
ami ids are broken

### DIFF
--- a/aerospike-new-vpc.json
+++ b/aerospike-new-vpc.json
@@ -59,7 +59,7 @@
     },
     "Mappings": {
         "RegionMap": {
-          "us-east-1" : {"name": "ami-d33667c4"},
+          "us-east-1" : {"name": "ami-f8e9b4ef"},
             "us-west-1" : {"name": "ami-e2cd8582"},
             "us-west-2" : {"name": "ami-f7b81d97"},
             "eu-west-1" : {"name": "ami-9e3b74ed"},


### PR DESCRIPTION
I've put a right id only for us-east-1
you can check them here https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Images:visibility=public-images;search=aerospike;sort=desc:name